### PR TITLE
feat(volumemigration): add support for preserving the metadata of PVC

### DIFF
--- a/cmd/volumes/batchmigrate.go
+++ b/cmd/volumes/batchmigrate.go
@@ -20,6 +20,7 @@ type batchMigrateVolumeOptions struct {
 	nodeSelector           []string
 	migrationMode          string
 	migrationFlags         string
+	preserveMetadata       bool
 
 	rsyncImage  string
 	rcloneImage string
@@ -38,7 +39,7 @@ func AddBatchMigrateVolumeOptions(flagSet *flag.FlagSet, opts *batchMigrateVolum
 	flagSet.StringSliceVar(&opts.nodeSelector, "node-selector", []string{}, "comma separated list of node labels used for nodeSelector of the migration job")
 	flagSet.StringVarP(&opts.migrationMode, "migration-mode", "m", "rsync", "Migration mode to use. Options: rsync, rclone")
 	flagSet.StringVarP(&opts.migrationFlags, "migration-flags", "f", "", "Additional flags to pass to the migration tool")
-
+	flagSet.BoolVar(&opts.preserveMetadata, "preserve-metadata", false, "Preserve the original metadata of the PVC")
 	// images
 	flagSet.StringVar(&opts.rsyncImage, "rsync-image", migratevolume.DefaultRSyncContainerImage, "Image used for the rsync migration tool")
 	flagSet.StringVar(&opts.rcloneImage, "rclone-image", migratevolume.DefaultRCloneContainerImage, "Image used for the rclone migration tool")
@@ -82,9 +83,9 @@ It is recommended to utilize the migration-flag option to pass additional flags 
 				MigrationMode:          migratevolume.MigrationMode(runOptions.migrationMode),
 				MigrationFlags:         runOptions.migrationFlags,
 				NodeSelector:           runOptions.nodeSelector,
-
-				RSyncImage:  runOptions.rsyncImage,
-				RCloneImage: runOptions.rcloneImage,
+				PreserveMetadata:       runOptions.preserveMetadata,
+				RSyncImage:             runOptions.rsyncImage,
+				RCloneImage:            runOptions.rcloneImage,
 			})
 		},
 	}

--- a/cmd/volumes/migrate.go
+++ b/cmd/volumes/migrate.go
@@ -20,6 +20,7 @@ type migrateVolumeOptions struct {
 	nodeSelector     []string
 	migrationMode    string
 	migrationFlags   string
+	preserveMetadata bool
 
 	rsyncImage  string
 	rcloneImage string
@@ -38,6 +39,7 @@ func AddMigrateVolumeOptions(flagSet *flag.FlagSet, opts *migrateVolumeOptions) 
 	flagSet.StringSliceVar(&opts.nodeSelector, "node-selector", []string{}, "comma separated list of node labels used for nodeSelector of the migration job")
 	flagSet.StringVarP(&opts.migrationMode, "migration-mode", "m", "rsync", "Migration mode to use. Options: rsync, rclone. Default is rsync with rclone being newly introduced")
 	flagSet.StringVarP(&opts.migrationFlags, "migration-flags", "f", "", "Additional flags to pass to the migration tool")
+	flagSet.BoolVar(&opts.preserveMetadata, "preserve-metadata", false, "Preserve the original metadata of the PVC")
 
 	// images
 	flagSet.StringVar(&opts.rsyncImage, "rsync-image", migratevolume.DefaultRSyncContainerImage, "Image used for the rsync migration tool")
@@ -81,9 +83,9 @@ It is recommended to utilize the migration-flag option to pass additional flags 
 				NodeSelector:     runOptions.nodeSelector,
 				MigrationMode:    migratevolume.MigrationMode(runOptions.migrationMode),
 				MigrationFlags:   runOptions.migrationFlags,
-
-				RCloneImage: runOptions.rcloneImage,
-				RyncImage:   runOptions.rsyncImage,
+				PreserveMetadata: runOptions.preserveMetadata,
+				RCloneImage:      runOptions.rcloneImage,
+				RyncImage:        runOptions.rsyncImage,
 			})
 		},
 	}

--- a/pkg/ame/migratevolume/batch.go
+++ b/pkg/ame/migratevolume/batch.go
@@ -20,6 +20,7 @@ type BatchMigrateOptions struct {
 	MigrationMode          MigrationMode
 	MigrationFlags         string
 	NodeSelector           []string
+	PreserveMetadata       bool
 
 	RSyncImage  string
 	RCloneImage string
@@ -108,6 +109,7 @@ func BatchMigrateVolumes(ctx context.Context, opts BatchMigrateOptions) error {
 			MigrationMode:    opts.MigrationMode,
 			MigrationFlags:   opts.MigrationFlags,
 			NodeSelector:     opts.NodeSelector,
+			PreserveMetadata: opts.PreserveMetadata,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to migrate volume job: %s", err)

--- a/pkg/ame/syncvolume/syncvolume.go
+++ b/pkg/ame/syncvolume/syncvolume.go
@@ -70,7 +70,7 @@ func SyncVolumeJob(ctx context.Context, opts SyncVolumeJobOptions) error {
 			sourcePVCStorageSize = resource.MustParse(fmt.Sprintf("%dM", opts.NewSize))
 		}
 
-		err = k8s.CreatePersistentVolumeClaim(ctx, k8sClient, opts.TargetPVCName, opts.Namespace, opts.NewStorageClassName, sourcePVCStorageSize)
+		err = k8s.CreatePersistentVolumeClaim(ctx, k8sClient, metav1.ObjectMeta{Name: opts.TargetPVCName, Namespace: opts.Namespace}, opts.NewStorageClassName, sourcePVCStorageSize)
 		if err != nil {
 			// if the pvc already exists while create-pvc option is true, an existing pvc is not used
 			if kubeerrors.IsAlreadyExists(err) {

--- a/pkg/k8s/volume_test.go
+++ b/pkg/k8s/volume_test.go
@@ -21,7 +21,7 @@ func TestCreatePersistentVolumeClaim(t *testing.T) {
 	namespace := "default"
 	storageClass := "ebs"
 
-	err := CreatePersistentVolumeClaim(context.TODO(), k8sClient, pvcName, namespace, storageClass, resource.MustParse("1"))
+	err := CreatePersistentVolumeClaim(context.TODO(), k8sClient, metav1.ObjectMeta{Name: pvcName, Namespace: namespace}, storageClass, resource.MustParse("1"))
 	if !assert.NoError(t, err, "should not receive an error when creating the pvc") {
 		t.FailNow()
 	}


### PR DESCRIPTION
add support for preserving the metadata of PVCs during volume migration to a new storage class

Necessary for use cases such as moving a PVC used by CNPG