### PR TITLE
feat: add label selector option for volume pruning

### DIFF
--- a/cmd/volumes/prune.go
+++ b/cmd/volumes/prune.go
@@ -1,6 +1,8 @@
 package volumes
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 
@@ -8,10 +10,11 @@ import (
 )
 
 type volumePruneOptions struct {
-	dryRun        bool
-	allNamespaces bool
-	pvcNamespace  string
-	labelSelector string
+	dryRun              bool
+	allNamespaces       bool
+	pvcNamespace        string
+	labelSelector       string
+	minReleasedDuration time.Duration
 }
 
 func newVolumePruneOptions() *volumePruneOptions {
@@ -23,6 +26,7 @@ func AddVolumePruneFlags(flagSet *flag.FlagSet, opts *volumePruneOptions) {
 	flagSet.BoolVarP(&opts.allNamespaces, "all", "A", false, "Prune volumes from all namespaces")
 	flagSet.StringVarP(&opts.pvcNamespace, "namespace", "n", "", "Namespace to prune volumes from. Volume namespaces are cluster scoped, so the namespace is only used to filter the PVCs")
 	flagSet.StringVarP(&opts.labelSelector, "label-selector", "l", "", "Label selector to filter the volumes to prune")
+	flagSet.DurationVar(&opts.minReleasedDuration, "min-released-duration", 0, "Minimum duration since the volume was released")
 }
 
 // NewVolumePruneCmd returns the Cobra Bootstrap sub command
@@ -48,10 +52,11 @@ acloud-toolkit storage prune -n my-namespace --dry-run=false
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := prune.Volumes(cmd.Context(), prune.Opts{
-				DryRun:        runOptions.dryRun,
-				AllNamespaces: runOptions.allNamespaces,
-				PvcNamespace:  runOptions.pvcNamespace,
-				LabelSelector: runOptions.labelSelector,
+				DryRun:              runOptions.dryRun,
+				AllNamespaces:       runOptions.allNamespaces,
+				PvcNamespace:        runOptions.pvcNamespace,
+				LabelSelector:       runOptions.labelSelector,
+				MinReleasedDuration: runOptions.minReleasedDuration,
 			}); err != nil {
 				return err
 			}

--- a/cmd/volumes/prune.go
+++ b/cmd/volumes/prune.go
@@ -11,6 +11,7 @@ type volumePruneOptions struct {
 	dryRun        bool
 	allNamespaces bool
 	pvcNamespace  string
+	labelSelector string
 }
 
 func newVolumePruneOptions() *volumePruneOptions {
@@ -21,6 +22,7 @@ func AddVolumePruneFlags(flagSet *flag.FlagSet, opts *volumePruneOptions) {
 	flagSet.BoolVar(&opts.dryRun, "dry-run", true, "Perform a dry run of volume prune")
 	flagSet.BoolVarP(&opts.allNamespaces, "all", "A", false, "Prune volumes from all namespaces")
 	flagSet.StringVarP(&opts.pvcNamespace, "namespace", "n", "", "Namespace to prune volumes from. Volume namespaces are cluster scoped, so the namespace is only used to filter the PVCs")
+	flagSet.StringVarP(&opts.labelSelector, "label-selector", "l", "", "Label selector to filter the volumes to prune")
 }
 
 // NewVolumePruneCmd returns the Cobra Bootstrap sub command
@@ -49,6 +51,7 @@ acloud-toolkit storage prune -n my-namespace --dry-run=false
 				DryRun:        runOptions.dryRun,
 				AllNamespaces: runOptions.allNamespaces,
 				PvcNamespace:  runOptions.pvcNamespace,
+				LabelSelector: runOptions.labelSelector,
 			}); err != nil {
 				return err
 			}

--- a/docs/acloud-toolkit_volumes_prune.md
+++ b/docs/acloud-toolkit_volumes_prune.md
@@ -23,6 +23,9 @@ acloud-toolkit storage prune -A --dry-run=false
 # Prune all persistent volumes that are set to Released within a specific namespace
 acloud-toolkit storage prune -n my-namespace --dry-run=false
 
+# Prune persistent volumes that have been released for at least 30 days
+acloud-toolkit storage prune --min-released-duration=720h --dry-run=false
+
 ```
 
 ### Options
@@ -31,6 +34,8 @@ acloud-toolkit storage prune -n my-namespace --dry-run=false
   -A, --all                Prune volumes from all namespaces
       --dry-run            Perform a dry run of volume prune (default true)
   -h, --help               help for prune
+  -l, --label-selector string   Label selector to filter the volumes to prune
+      --min-released-duration duration   Minimum duration since the volume was released (e.g., 720h for 30 days)
   -n, --namespace string   Namespace to prune volumes from. Volume namespaces are cluster scoped, so the namespace is only used to filter the PVCs
 ```
 

--- a/pkg/ame/prune/prune.go
+++ b/pkg/ame/prune/prune.go
@@ -16,6 +16,7 @@ type Opts struct {
 	DryRun        bool
 	AllNamespaces bool
 	PvcNamespace  string
+	LabelSelector string
 }
 
 func Volumes(ctx context.Context, opts Opts) error {
@@ -40,7 +41,11 @@ func Volumes(ctx context.Context, opts Opts) error {
 		namespace = contextNamespace
 	}
 
-	pvs, err := k8sClient.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	listOptions := metav1.ListOptions{}
+	if opts.LabelSelector != "" {
+		listOptions.LabelSelector = opts.LabelSelector
+	}
+	pvs, err := k8sClient.CoreV1().PersistentVolumes().List(ctx, listOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This update introduces a new `labelSelector` field in the volume prune options, allowing users to filter volumes based on labels for pruning unused/released volumes.

Quality of live improvement for us, as not all `Released` volumes should be removed.
Also added an option to filter based on how long ago the volumes were released.
