### PR TITLE
chore: remove `conflicts_with` from homebrew release as its deprecated

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,8 +28,6 @@ homebrew_casks:
       name: homebrew-tools
       token: "{{ .Env.HOMEBREW_TOOLS_GITHUB_TOKEN }}"
     homepage: "https://docs.avisi.cloud/docs/cli/acloud-toolkit/overview"
-    conflicts:
-      - formula: acloud-toolkit
     completions:
       bash: completions/acloud-toolkit.bash
       zsh: completions/acloud-toolkit.zsh


### PR DESCRIPTION
```sh
Warning: Calling conflicts_with formula: is deprecated! There is no replacement.
Please report this issue to the avisi-cloud/homebrew-tools tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/avisi-cloud/homebrew-tools/Casks/acloud-toolkit.rb:38
```